### PR TITLE
reduce: don't need brackets for errors | fix: in description

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ class fseasy extends event {
   }
 
   appendFile(file, text) {
-    if (!file) throw new Error("FsEasy Error: File is not defined.")
+    if (!file) throw new Error("FsEasy Error: File is not provided.")
 
     if (!text) {
       throw new Error("FsEasy Error: Blank text cannot be written.")

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,7 @@ const event = require("events")
 
 class fseasy extends event {
   readFile(file, property) {
-    if (!file) {
-      throw new Error("FsEasy Error: File is not provided.")
-    }
+    if (!file) throw new Error("FsEasy Error: File is not provided.")
 
     if (!property) {
        fs.readFileSync(file, "utf8")
@@ -18,39 +16,30 @@ class fseasy extends event {
   }
 
   writeFile(file, text) {
-    if (!file) {
-      throw new Error("FsEasy Error: File is not provided.")
-    }
+    if (!file) throw new Error("FsEasy Error: File is not provided.")
 
-    if (!text) {
-      throw new Error("FsEasy Error: Blank text cannot be written.")
-    } else {
+    if (!text) throw new Error("FsEasy Error: Blank text cannot be written.")
       fs.writeFile(file, text, (err) => {
         if (err) throw err;
         this.emit("writeFile" , {file: file, content: text})
       })
-    }
   }
 
   appendFile(file, text) {
-    if (!file) {
-      throw new Error("FsEasy Error: File is not defined.")
-    }
+    if (!file) throw new Error("FsEasy Error: File is not defined.")
 
     if (!text) {
       throw new Error("FsEasy Error: Blank text cannot be written.")
     } else {
       fs.appendFile(file, text, (err) => {
-        if (err) throw err;
+        if (err) throw new Error("FsEasy Error: Could not append file.")
         this.emit("appendFile" , { file: file, content: text})
       })
     }
   }
 
  fileExists(file){
-   if(!file){
-     throw new Error("FsEasy Error: File is not defined")
-   }
+   if(!file) throw new Error("FsEasy Error: File is not provided.")
   return fs.fileExists(file) //boolean
  }
 


### PR DESCRIPTION
If append file function fails, throws fs error but this package's name is fseasy. So error is customized to "FsEasy Error: Could not append file."